### PR TITLE
Add new "mobile" attribute which enables showing the native select at "xs" resolution

### DIFF
--- a/app/templates/components/list-picker.hbs
+++ b/app/templates/components/list-picker.hbs
@@ -1,5 +1,6 @@
 {{view "select"
-       class="native-select visible-xs-inline"
+       class="native-select"
+       classNameBindings="mobile:visible-xs-inline:hidden"
        content=content
        selection=selection
        value=value
@@ -11,7 +12,7 @@
        optionLabelPath=optionLabelPath
        optionValuePath=optionValuePath}}
 
-<div {{bind-attr class=":bs-select :hidden-xs disabled:disabled"}}>
+<div {{bind-attr class=":bs-select mobile:hidden-xs disabled:disabled"}}>
   {{#if liveSearch}}
     <div class="input-group">
       {{input type="text" class="search-filter form-control" value=searchFilter action="preventClosing" on="focus"}}

--- a/app/templates/components/select-picker.hbs
+++ b/app/templates/components/select-picker.hbs
@@ -1,5 +1,6 @@
 {{view "select"
-       class="native-select visible-xs-inline"
+       class="native-select"
+       classNameBindings="mobile:visible-xs-inline:hidden"
        content=content
        selection=selection
        value=value
@@ -11,7 +12,7 @@
        optionLabelPath=optionLabelPath
        optionValuePath=optionValuePath}}
 
-<div {{bind-attr class=":bs-select :btn-group :dropdown :hidden-xs disabled:disabled showDropdown:open"}}>
+<div {{bind-attr class=":bs-select :btn-group :dropdown mobile:hidden-xs disabled:disabled showDropdown:open"}}>
   <button type="button"
           {{bind-attr class=":btn :btn-default :dropdown-toggle class"}}
           {{bind-attr id=menuButtonId}}


### PR DESCRIPTION
I thought it would be best to turn this behavior off by default, since I think it's somewhat unexpected for most users.
