### PR TITLE
Fix broken devDependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -39,7 +39,7 @@
     "ember-data": "1.0.0-beta.15",
     "ember-export-application-global": "^1.0.2",
     "express": "^4.8.5",
-    "glob": "^4.0.5"
+    "glob": "^4.5.3"
   },
   "keywords": [
     "ember-addon",


### PR DESCRIPTION
Refer to https://github.com/ember-cli/ember-cli/issues/3516

This prevented tests from running.

Note you may need to run `npm rm glob && npm up` after pulling this PR to see the fix.
