### PR TITLE
Fix bad assumptions on Ember prototypes

### DIFF
--- a/addon/mixins/select-picker.js
+++ b/addon/mixins/select-picker.js
@@ -120,6 +120,24 @@ var SelectPickerMixin = Ember.Mixin.create({
     }
   ),
 
+  groupedContentList: Ember.computed(
+    'contentList.@each',
+    function() {
+      var lastGroup;
+      var result = Ember.A(this.get('contentList'))
+        .map(function(item) {
+          var clonedItem = Ember.copy(item);
+          if (clonedItem.group === lastGroup) {
+            clonedItem.group = null;
+          } else {
+            lastGroup = clonedItem.group;
+          }
+          return clonedItem;
+        });
+      return Ember.A(result);
+    }
+  ),
+
   contentPathName: function(pathName) {
     return this.getWithDefault(pathName, '').substr(8);
   },

--- a/addon/mixins/select-picker.js
+++ b/addon/mixins/select-picker.js
@@ -94,13 +94,13 @@ var SelectPickerMixin = Ember.Mixin.create({
           var value = Ember.get(item, valuePath);
           var group = groupPath ? Ember.get(item, groupPath) : null;
           if (searchMatcher(group) || searchMatcher(label)) {
-            return {
+            return Ember.Object.create({
               item:     item,
               group:    group,
               label:    label,
               value:    value,
               selected: selection.contains(item)
-            };
+            });
           } else {
             return null;
           }
@@ -108,33 +108,32 @@ var SelectPickerMixin = Ember.Mixin.create({
 
       // Ember Addons need to be coded as if Ember.EXTEND_PROTOTYPES = false
       // Because of this we need to manually extend our native array from the
-      // above map() function. compact() is an Ember function and so returns
-      // an Ember.Array which is what we want anyway.
-      result = Ember.A(result).compact();
+      // above map() function. Even though compact() is an Ember function it
+      // too sufferes from the same fate.
+      result = Ember.A(Ember.A(result).compact());
 
-      if (result[0]) {
-        result[0].first = true;
+      if (!Ember.isEmpty(result)) {
+        result.get('firstObject').set('first', true);
       }
 
-      return Ember.A(result);
+      return result;
     }
   ),
 
   groupedContentList: Ember.computed(
-    'contentList.@each',
+    'contentList.@each.group',
     function() {
       var lastGroup;
-      var result = Ember.A(this.get('contentList'))
-        .map(function(item) {
-          var clonedItem = Ember.copy(item);
-          if (clonedItem.group === lastGroup) {
-            clonedItem.group = null;
-          } else {
-            lastGroup = clonedItem.group;
-          }
-          return clonedItem;
-        });
-      return Ember.A(result);
+      var result = Ember.A(this.get('contentList'));
+      result.forEach(function(item) {
+        let group = item.get('group');
+        if (group === lastGroup) {
+          item.set('group', null);
+        } else {
+          lastGroup = group;
+        }
+      });
+      return result;
     }
   ),
 
@@ -179,7 +178,7 @@ var SelectPickerMixin = Ember.Mixin.create({
   },
 
   selectionSummary: Ember.computed(
-    'selection.@each',
+    'selection.@each', 'prompt',
     function() {
       var selection = this.selectionAsArray();
       if (Ember.I18n) {
@@ -190,7 +189,7 @@ var SelectPickerMixin = Ember.Mixin.create({
         case 0:
           return this.get('prompt') || 'Nothing Selected';
         case 1:
-          return this.getByContentPath(selection[0], 'optionLabelPath');
+          return this.getByContentPath(selection.get('firstObject'), 'optionLabelPath');
         default:
           return Ember.String.fmt(this.get('summaryMessage'), selection.length);
       }

--- a/app/components/list-picker.js
+++ b/app/components/list-picker.js
@@ -18,18 +18,18 @@ var ListPickerComponent = Ember.Component.extend(
     function() {
       var groups = Ember.A();
       var content = Ember.A();
-      Ember.A(this.get('contentList')).forEach(function(item) {
-        var header;
-        var groupIndex = groups.indexOf(item.group);
+      this.get('contentList').forEach(function(item) {
+        var header, itemGroup = item.get('group');
+        var groupIndex = groups.indexOf(itemGroup);
         if (groupIndex < 0) {
-          header = item.group;
+          header = itemGroup;
           groups.push(header);
-          content.push({
+          content.push(Ember.Object.create({
             header: header,
             items: Ember.A([item])
-          });
+          }));
         } else {
-          content[groupIndex].items.push(item);
+          content[groupIndex].get('items').push(item);
         }
       });
       return content;

--- a/app/components/list-picker.js
+++ b/app/components/list-picker.js
@@ -9,6 +9,8 @@ var ListPickerComponent = Ember.Component.extend(
   selectAllLabel:  'Select All',
   selectNoneLabel: 'Select None',
 
+  nativeMobile: false,
+
   classNames: ['select-picker', 'list-picker'],
 
   groupedContentList: Ember.computed(

--- a/app/components/select-picker.js
+++ b/app/components/select-picker.js
@@ -29,24 +29,6 @@ var SelectPickerComponent = Ember.Component.extend(
     $(document).off('.' + this.get('elementId'));
   },
 
-  groupedContentList: Ember.computed(
-    'contentList.@each',
-    function() {
-      var lastGroup;
-      var result = Ember.A(this.get('contentList'))
-        .map(function(item) {
-          var clonedItem = Ember.copy(item);
-          if (clonedItem.group === lastGroup) {
-            clonedItem.group = null;
-          } else {
-            lastGroup = clonedItem.group;
-          }
-          return clonedItem;
-        });
-      return Ember.A(result);
-    }
-  ),
-
   actions: {
     showHide: function () {
       this.toggleProperty('showDropdown');

--- a/app/components/select-picker.js
+++ b/app/components/select-picker.js
@@ -9,6 +9,8 @@ var SelectPickerComponent = Ember.Component.extend(
   selectAllLabel:  'All',
   selectNoneLabel: 'None',
 
+  nativeMobile: true,
+
   classNames: ['select-picker'],
 
   didInsertElement: function() {

--- a/app/templates/components/list-picker.hbs
+++ b/app/templates/components/list-picker.hbs
@@ -1,6 +1,6 @@
 {{view "select"
        class="native-select"
-       classNameBindings="mobile:visible-xs-inline:hidden"
+       classNameBindings="nativeMobile:visible-xs-inline:hidden"
        content=content
        selection=selection
        value=value
@@ -12,7 +12,7 @@
        optionLabelPath=optionLabelPath
        optionValuePath=optionValuePath}}
 
-<div {{bind-attr class=":bs-select mobile:hidden-xs disabled:disabled"}}>
+<div {{bind-attr class=":bs-select nativeMobile:hidden-xs disabled:disabled"}}>
   {{#if liveSearch}}
     <div class="input-group">
       {{input type="text" class="search-filter form-control" value=searchFilter action="preventClosing" on="focus"}}

--- a/app/templates/components/select-picker.hbs
+++ b/app/templates/components/select-picker.hbs
@@ -1,6 +1,6 @@
 {{view "select"
        class="native-select"
-       classNameBindings="mobile:visible-xs-inline:hidden"
+       classNameBindings="nativeMobile:visible-xs-inline:hidden"
        content=content
        selection=selection
        value=value
@@ -12,7 +12,7 @@
        optionLabelPath=optionLabelPath
        optionValuePath=optionValuePath}}
 
-<div {{bind-attr class=":bs-select :btn-group :dropdown mobile:hidden-xs disabled:disabled showDropdown:open"}}>
+<div {{bind-attr class=":bs-select :btn-group :dropdown nativeMobile:hidden-xs disabled:disabled showDropdown:open"}}>
   <button type="button"
           {{bind-attr class=":btn :btn-default :dropdown-toggle class"}}
           {{bind-attr id=menuButtonId}}


### PR DESCRIPTION
With the EXTEND_PROTOTYPES:false option in add-ons it is best to make all objects and arrays ember versions. Unfortunately it is easy to miss this in normal coding and thankfully the tests are a saving grace here.
