### PR TITLE
Use Ember.observer over named properties

### DIFF
--- a/app/components/select-picker.js
+++ b/app/components/select-picker.js
@@ -13,23 +13,29 @@ var SelectPickerComponent = Ember.Component.extend(
 
   classNames: ['select-picker'],
 
-  didInsertElement: function() {
-    var eventName = 'click.' + this.get('elementId');
-    var _this = this;
-    $(document).on(eventName, function (e) {
-      if (_this.get('keepDropdownOpen')) {
-        _this.set('keepDropdownOpen', false);
-        return;
-      }
-      if (_this.element && !$.contains(_this.element, e.target)) {
-        _this.set('showDropdown', false);
-      }
-    });
-  },
+  setupDom: Ember.observer(
+    'didInsertElement',
+    function() {
+      var eventName = 'click.' + this.get('elementId');
+      var _this = this;
+      $(document).on(eventName, function (e) {
+        if (_this.get('keepDropdownOpen')) {
+          _this.set('keepDropdownOpen', false);
+          return;
+        }
+        if (_this.element && !$.contains(_this.element, e.target)) {
+          _this.set('showDropdown', false);
+        }
+      });
+    }
+  ),
 
-  willDestroyElement: function() {
-    $(document).off('.' + this.get('elementId'));
-  },
+  teardownDom: Ember.observer(
+    'willDestroyElement',
+    function() {
+      $(document).off('.' + this.get('elementId'));
+    }
+  ),
 
   actions: {
     showHide: function () {


### PR DESCRIPTION
The named properties are a convenience but makes it harder to overload later on. It is better to use observers and in the case of an addon the Ember.observer() pattern
