### PR TITLE
Fix double translation keys

### DIFF
--- a/addon/mixins/select-picker.js
+++ b/addon/mixins/select-picker.js
@@ -178,14 +178,16 @@ var SelectPickerMixin = Ember.Mixin.create({
   },
 
   selectionSummary: Ember.computed(
-    'selection.@each', 'prompt',
+    'selection.@each', 'prompt', 'summaryMessage',
     function() {
       var selection = this.selectionAsArray();
-      if (Ember.I18n) {
-        return Ember.I18n.t(this.get('summaryMessage'), {count: selection.length});
+      var messageKey = this.get('summaryMessageTranslation');
+      if (Ember.I18n && Ember.isPresent(messageKey)) {
+        // I18n for prompt can be managed by using the pluralization feature:
+        // https://github.com/jamesarosen/ember-i18n#pluralization
+        return Ember.I18n.t(messageKey, {count: selection.length});
       }
       switch (selection.length) {
-        // I18n done by promptTranslate property (I18n plugin)
         case 0:
           return this.get('prompt') || 'Nothing Selected';
         case 1:


### PR DESCRIPTION
Using summaryMessage with the I18n module caused a double key

summaryMessageTranslation="foo" cause this.get('summaryMessage') to return the translated value which we then attempted to translate again.

Now we only do it once.
