### PR TITLE
Use proper event management for closing menu

### DIFF
--- a/app/components/select-picker.js
+++ b/app/components/select-picker.js
@@ -13,29 +13,23 @@ var SelectPickerComponent = Ember.Component.extend(
 
   classNames: ['select-picker'],
 
-  setupDom: Ember.observer(
-    'didInsertElement',
-    function() {
-      var eventName = 'click.' + this.get('elementId');
-      var _this = this;
-      $(document).on(eventName, function (e) {
-        if (_this.get('keepDropdownOpen')) {
-          _this.set('keepDropdownOpen', false);
-          return;
-        }
-        if (_this.element && !$.contains(_this.element, e.target)) {
-          _this.set('showDropdown', false);
-        }
-      });
-    }
-  ),
+  setupDom: Ember.on('didInsertElement', function() {
+    var eventName = 'click.' + this.get('elementId');
+    var _this = this;
+    $(document).on(eventName, function (e) {
+      if (_this.get('keepDropdownOpen')) {
+        _this.set('keepDropdownOpen', false);
+        return;
+      }
+      if (_this.element && !$.contains(_this.element, e.target)) {
+        _this.set('showDropdown', false);
+      }
+    });
+  }),
 
-  teardownDom: Ember.observer(
-    'willDestroyElement',
-    function() {
-      $(document).off('.' + this.get('elementId'));
-    }
-  ),
+  teardownDom: Ember.on('willDestroyElement', function() {
+    $(document).off('.' + this.get('elementId'));
+  }),
 
   actions: {
     showHide: function () {

--- a/tests/integration/select-picker-test.js
+++ b/tests/integration/select-picker-test.js
@@ -22,7 +22,8 @@ module('Select Picker Integration', {
 });
 
 test('Show and Hide', function(assert) {
-  assert.expect(2);
+  assert.expect(3);
+
   visit('/test-select-picker')
 
   .then(function() {
@@ -38,6 +39,15 @@ test('Show and Hide', function(assert) {
     assert.ok(
       find('#single-picker .dropdown-menu').is(':visible'),
       'dropdown menu should be visible'
+    );
+  })
+
+  .click('#single-picker')
+
+  .then(function() {
+    assert.ok(
+      find('#single-picker .dropdown-menu').is(':hidden'),
+      'dropdown menu should be hidden'
     );
   });
 });


### PR DESCRIPTION
The didInsertElement and willDestroyElement events were not being ran because I was using an observer not an on. Also added some tests to pick this up.
