### PR TITLE
Refactor the summaryMessage logic

### DIFF
--- a/addon/mixins/select-picker.js
+++ b/addon/mixins/select-picker.js
@@ -58,8 +58,9 @@ var SelectPickerMixin = Ember.Mixin.create({
   selectionAsArray: function() {
     var selection = this.get('selection');
     if (Ember.isNone(selection)) {
-      return Ember.A();
-    } else if (!Ember.isArray(selection)) {
+      selection = this.get('value');
+    }
+    if (!Ember.isArray(selection)) {
       return Ember.A([selection]);
     }
     return Ember.A(selection);
@@ -172,40 +173,34 @@ var SelectPickerMixin = Ember.Mixin.create({
     }
   },
 
-  selectionLabels: Ember.computed(
-    'selection.@each',
-    function() {
-      var result = this.selectionAsArray()
-        .map(Ember.run.bind(this, function(item) {
-          return this.getByContentPath(item, 'optionLabelPath');
-        }));
-      return Ember.A(result);
-    }
-  ),
+  selectionLabels: Ember.computed.mapBy('selectedContentList', 'label'),
 
   selectionSummary: Ember.computed(
-    'selectionLabels.@each', 'prompt', 'summaryMessage',
+    'selectionLabels.[]', 'prompt', 'summaryMessage', 'summaryMessageKey',
     function() {
       var selection = this.get('selectionLabels');
-      var messageKey = this.get('summaryMessageTranslation');
+      var count = selection.get('length');
+      var messageKey = this.get('summaryMessageKey');
       if (Ember.I18n && Ember.isPresent(messageKey)) {
-        // I18n for prompt can be managed by using the pluralization feature:
-        // https://github.com/jamesarosen/ember-i18n#pluralization
+        // TODO: Allow an enablePrompt="false" feature
+        if (count === 0) {
+          return this.get('prompt');
+        }
         return Ember.I18n.t(messageKey, {
-          count: selection.length,
+          count: count,
           item: selection.get('firstObject'),
           list: selection.join(', ')
         });
       }
-      switch (selection.length) {
+      switch (count) {
         case 0:
-          return this.get('prompt') || 'Nothing Selected';
+          return this.get('prompt');
         case 1:
           return selection.get('firstObject');
         default:
           return Ember.String.fmt(
             this.get('summaryMessage'),
-            selection.length,
+            count,
             selection.get('firstObject'),
             selection.join(', ')
           );

--- a/addon/mixins/select-picker.js
+++ b/addon/mixins/select-picker.js
@@ -45,12 +45,8 @@ var isAdvancedSearch = function(liveSearch) {
 };
 
 var SelectPickerMixin = Ember.Mixin.create({
-  liveSearch:     false,
-  showDropdown:   false,
-  prompt:         false,
-  content:        [],
-  selection:      [],
-  summaryMessage: '%@ items selected',
+  liveSearch:   false,
+  showDropdown: false,
 
   menuButtonId: Ember.computed(
     'elementId',

--- a/app/components/select-picker.js
+++ b/app/components/select-picker.js
@@ -6,6 +6,8 @@ var I18nProps = (Ember.I18n && Ember.I18n.TranslateableProperties) || {};
 var SelectPickerComponent = Ember.Component.extend(
   SelectPickerMixin, I18nProps, {
 
+  prompt:          'Nothing Selected',
+  summaryMessage:  '%@ items selected',
   selectAllLabel:  'All',
   selectNoneLabel: 'None',
 


### PR DESCRIPTION
The logic was tripping over it's own feet because the I18n setup and how it handles the translatable properties. The only way out of the rats nest was to use summaryMessageKey instead and do our own translation in a computed property. Documentation will have to be clear on this discrepancy.

This was a valiant attempt to slay the Hydra that is I18n! Things got quite complicated but I think I finally tamed the :dragon:
