### PR TITLE
Add form-control to native select picker

### DIFF
--- a/app/templates/components/list-picker.hbs
+++ b/app/templates/components/list-picker.hbs
@@ -1,5 +1,5 @@
 {{view "select"
-       class="native-select"
+       class="native-select form-control"
        classNameBindings="nativeMobile:visible-xs-inline:hidden"
        content=content
        selection=selection

--- a/app/templates/components/select-picker.hbs
+++ b/app/templates/components/select-picker.hbs
@@ -1,5 +1,5 @@
 {{view "select"
-       class="native-select"
+       class="native-select form-control"
        classNameBindings="nativeMobile:visible-xs-inline:hidden"
        content=content
        selection=selection


### PR DESCRIPTION
This is so small screens which use the native picker will have the bootstrap style as intended.
