### PR TITLE
Remove default prompt

### DIFF
--- a/addon/mixins/select-picker.js
+++ b/addon/mixins/select-picker.js
@@ -189,7 +189,7 @@ var SelectPickerMixin = Ember.Mixin.create({
   selectionLabels: Ember.computed.mapBy('selectedContentList', 'label'),
 
   selectionSummary: Ember.computed(
-    'selectionLabels.[]', 'prompt', 'summaryMessage', 'summaryMessageKey',
+    'selectionLabels.[]', 'nothingSelectedMessage', 'summaryMessage', 'summaryMessageKey',
     function() {
       var selection = this.get('selectionLabels');
       var count = selection.get('length');
@@ -197,7 +197,7 @@ var SelectPickerMixin = Ember.Mixin.create({
       if (Ember.I18n && Ember.isPresent(messageKey)) {
         // TODO: Allow an enablePrompt="false" feature
         if (count === 0) {
-          return this.get('prompt');
+          return this.get('nothingSelectedMessage');
         }
         return Ember.I18n.t(messageKey, {
           count: count,
@@ -207,7 +207,7 @@ var SelectPickerMixin = Ember.Mixin.create({
       }
       switch (count) {
         case 0:
-          return this.get('prompt');
+          return this.get('nothingSelectedMessage');
         case 1:
           return selection.get('firstObject');
         default:

--- a/app/components/select-picker.js
+++ b/app/components/select-picker.js
@@ -6,10 +6,10 @@ var I18nProps = (Ember.I18n && Ember.I18n.TranslateableProperties) || {};
 var SelectPickerComponent = Ember.Component.extend(
   SelectPickerMixin, I18nProps, {
 
-  prompt:          'Nothing Selected',
-  summaryMessage:  '%@ items selected',
-  selectAllLabel:  'All',
-  selectNoneLabel: 'None',
+  nothingSelectedMessage: 'Nothing Selected',
+  summaryMessage:         '%@ items selected',
+  selectAllLabel:         'All',
+  selectNoneLabel:        'None',
 
   nativeMobile: true,
 

--- a/vendor/select-picker.css
+++ b/vendor/select-picker.css
@@ -1,3 +1,10 @@
+/* Fix to enable Ember actions
+ * http://stackoverflow.com/a/17490775/227176
+ */
+.select-picker .btn-group .dropdown-menu li a {
+  cursor: pointer;
+}
+
 .select-picker .btn-group .dropdown-menu li.selected a span.check-mark {
   position:   absolute;
   display:    inline-block;


### PR DESCRIPTION
The prompt adds an extra selection in the native drop down. This is something that some people might want to avoid. Rename the message so it doesn't name conflict with prompt and allow prompt to be managed only by users.
