### PR TITLE
Fix broken btn-group styling

### DIFF
--- a/app/components/select-picker.js
+++ b/app/components/select-picker.js
@@ -13,7 +13,7 @@ var SelectPickerComponent = Ember.Component.extend(
 
   nativeMobile: true,
 
-  classNames: ['select-picker'],
+  classNames: ['select-picker', 'btn-group'],
 
   badgeEnabled: Ember.computed.and('showBadge', 'multiple'),
 

--- a/app/templates/components/select-picker.hbs
+++ b/app/templates/components/select-picker.hbs
@@ -12,7 +12,7 @@
        optionLabelPath=optionLabelPath
        optionValuePath=optionValuePath}}
 
-<div {{bind-attr class=":bs-select :btn-group :dropdown nativeMobile:hidden-xs disabled:disabled showDropdown:open"}}>
+<div {{bind-attr class=":bs-select :dropdown nativeMobile:hidden-xs disabled:disabled showDropdown:open"}}>
   <button type="button"
           {{bind-attr class=":btn :btn-default :dropdown-toggle class"}}
           {{bind-attr id=menuButtonId}}


### PR DESCRIPTION
Ember components are wrapped in a tag by default and using a div as the parent and then a div as a .btn-group seems to break the inline nature.

Adding .btn-group to the parent div renders better for bootstrap.
