### PR TITLE
Prevent an undefined selection

### DIFF
--- a/app/components/keyboard-select-picker.js
+++ b/app/components/keyboard-select-picker.js
@@ -82,7 +82,10 @@ var KeyboardSelectPickerComponent = SelectPicker.extend(
     }),
 
     selectActiveItem: makeKeyboardAction(function() {
-      this.send('selectItem', this.get('activeItem'));
+      var item = this.get('activeItem');
+      if (Ember.isPresent(item)) {
+        this.send('selectItem', item);
+      }
     }),
   }
 });


### PR DESCRIPTION
With keyboard select is was possible to press enter and select the activeItem when the activeIndex hasn;t been set yet (nothing selected by default) and so the syste, would selectItem on undefined.
