### PR TITLE
fix bind-attr and action-on-focus deprecations

### DIFF
--- a/app/templates/components/list-picker.hbs
+++ b/app/templates/components/list-picker.hbs
@@ -12,14 +12,14 @@
        optionLabelPath=optionLabelPath
        optionValuePath=optionValuePath}}
 
-<div {{bind-attr class=":bs-select nativeMobile:hidden-xs disabled:disabled"}}>
+<div class="bs-select {{if nativeMobile 'hidden-xs'}} {{if disabled 'disabled'}}">
   {{#if liveSearch}}
     <div class="input-group">
-      {{input type="text" class="search-filter form-control" value=searchFilter action="preventClosing" on="focus"}}
+      {{input type="text" class="search-filter form-control" value=searchFilter focus="preventClosing"}}
       <span class="input-group-btn">
         <button type="button"
                 class="btn btn-default list-picker-clear-filter"
-                {{bind-attr disabled=clearSearchDisabled}}
+                disabled={{clearSearchDisabled}}
                 {{action "clearFilter"}}>
           <span class="glyphicon glyphicon-remove"></span>
         </button>
@@ -36,7 +36,7 @@
       <div role="group" class="btn-group-vertical btn-block">
         <button type="button" class="btn btn-default" {{action "toggleSelectAllNone"}}>
           {{selectAllNoneLabel}}
-          <span {{bind-attr class=":check-mark :glyphicon glyphiconClass"}}></span>
+          <span class="check-mark glyphicon {{glyphiconClass}}"></span>
         </button>
       </div>
     {{/if}}
@@ -49,9 +49,9 @@
       {{#each group.items as |item|}}
         <button role="presentation"
                 {{action "selectItem" item}}
-                {{bind-attr class=":btn :btn-default item.selected:active"}}>
+                class="btn btn-default {{if item.selected 'active'}}">
           {{item.label}}
-          <span {{bind-attr class=":glyphicon :glyphicon-ok :check-mark item.selected::invisible"}}></span>
+          <span class="glyphicon glyphicon-ok check-mark {{if item.selected '' 'invisible'}}"></span>
         </button>
       {{/each}}
     </div>

--- a/app/templates/components/select-picker.hbs
+++ b/app/templates/components/select-picker.hbs
@@ -12,22 +12,22 @@
        optionLabelPath=optionLabelPath
        optionValuePath=optionValuePath}}
 
-<div {{bind-attr class=":bs-select :dropdown nativeMobile:hidden-xs disabled:disabled showDropdown:open"}}>
+<div class="bs-select dropdown {{if nativeMobile 'hidden-xs'}} {{if disabled 'disabled'}} {{if showDropdown 'open'}}">
   <button type="button"
-          {{bind-attr class=":btn :dropdown-toggle buttonClass"}}
-          {{bind-attr id=menuButtonId}}
-          {{bind-attr disabled=disabled}}
+          class="btn dropdown-toggle {{buttonClass}}"
+          id={{menuButtonId}}
+          disabled={{disabled}}
           {{action "showHide"}}
           aria-expanded="true">
     <span class="pull-left">
       {{selectionSummary}}
-      <span {{bind-attr class="selectionBadge:badge:caret"}}>{{selectionBadge}}</span>
+      <span class="{{if selectionBadge 'badge' 'caret'}}">{{selectionBadge}}</span>
     </span>
   </button>
-  <ul class="dropdown-menu" role="menu" {{bind-attr aria-labelledby=menuButtonId}}>
+  <ul class="dropdown-menu" role="menu" aria-labelledby={{menuButtonId}}>
     {{#if liveSearch}}
       <li>
-        {{input type="text" class="search-filter form-control" value=searchFilter action="preventClosing" on="focus"}}
+        {{input type="text" class="search-filter form-control" value=searchFilter focus="preventClosing"}}
       </li>
     {{/if}}
     {{#if multiple}}
@@ -40,7 +40,7 @@
         {{else}}
           <button type="button" class="btn btn-default btn-xs btn-block" {{action "toggleSelectAllNone"}}>
             {{selectAllNoneLabel}}
-            <span {{bind-attr class=":check-mark :glyphicon glyphiconClass"}}></span>
+            <span class="check-mark glyphicon {{glyphiconClass}}"></span>
           </button>
         {{/if}}
       </li>
@@ -50,10 +50,10 @@
         {{#unless item.first}}<li class="divider" role="presentation"></li>{{/unless}}
         <li class="dropdown-header" role="presentation">{{item.group}}</li>
       {{/if}}
-      <li role="presentation" {{bind-attr class="item.active:active item.selected:selected"}}>
+      <li role="presentation" class="{{if item.active 'active'}} {{if item.selected 'selected'}}">
         <a role="menuitem" tabindex="-1" {{action "selectItem" item}}>
           {{item.label}}
-          <span {{bind-attr class=":glyphicon :glyphicon-ok :check-mark item.selected::hidden"}}></span>
+          <span class="glyphicon glyphicon-ok check-mark {{if item.selected '' 'hidden'}}"></span>
         </a>
       </li>
     {{/each}}


### PR DESCRIPTION
This is suppossed to fix a few deprecations with latest Ember (CLI). There is still the `view "select"` deprecation left, which requires more refactoring (see http://emberjs.com/deprecations/v1.x/#toc_ember-select). Maybe solve this in the scope of #30?

The problem with my PR is, that it causes parsing errors (`Expecting 'CLOSE_RAW_BLOCK', 'CLOSE', 'CLOSE_UNESCAPED' ....`) on elements that appear perfectly fine. I thought maybe updating this addon's Ember might solve this, but this isn't the case. So I think this is a bug with `htmlbars` or do you have an idea? Nevertheless, I will submit a PR for updating Ember in case you might want it.
