### PR TITLE
Adjust popup location based on space available

### DIFF
--- a/app/components/select-picker.js
+++ b/app/components/select-picker.js
@@ -28,10 +28,12 @@ export default Ember.Component.extend(
   ),
 
   setupDom: Ember.on('didInsertElement', function() {
-    $(document).on(
-      `click.${this.get('elementId')}`,
-      Ember.run.bind(this, this.hideDropdownMenu)
-    );
+    const id = this.get('elementId');
+    this.updateDropUp();
+    $(document)
+      .on(`click.${id}`,  Ember.run.bind(this, this.hideDropdownMenu))
+      .on(`scroll.${id}`, Ember.run.bind(this, this.updateDropUp))
+      .on(`resize.${id}`, Ember.run.bind(this, this.updateDropUp));
   }),
 
   hideDropdownMenu: function(evt) {
@@ -42,6 +44,17 @@ export default Ember.Component.extend(
     if (this.element && !$.contains(this.element, evt.target)) {
       this.send('closeDropdown');
     }
+  },
+
+  updateDropUp() {
+    const windowHeight   = $(window).height();
+    const scrollTop      = $(window).scrollTop();
+    const buttonOffset   = this.$().offset().top;
+    const buttonHeight   = this.$().height();
+    const menuHeight     = this.$('.dropdown-menu').height();
+    const viewportOffset = buttonOffset - scrollTop;
+    const menuBottom     = viewportOffset + buttonHeight + menuHeight;
+    this.set('isDropUp', menuBottom > windowHeight);
   },
 
   teardownDom: Ember.on('willDestroyElement', function() {

--- a/app/components/select-picker.js
+++ b/app/components/select-picker.js
@@ -21,8 +21,8 @@ export default Ember.Component.extend(
   selectionBadge: Ember.computed(
     'selection.length', 'badgeEnabled',
     function() {
-      var enabled = this.get('badgeEnabled');
-      var selected = this.get('selection.length');
+      const enabled = this.get('badgeEnabled');
+      const selected = this.get('selection.length');
       return (enabled && selected && selected !== 0) ? selected : '';
     }
   ),

--- a/app/templates/components/select-picker.hbs
+++ b/app/templates/components/select-picker.hbs
@@ -5,7 +5,7 @@
   </div>
 {{/if}}
 
-<div class="bs-select dropdown {{if nativeMobile 'hidden-xs'}} {{if disabled 'disabled'}} {{if showDropdown 'open'}}"
+<div class="bs-select dropdown {{if isDropUp 'dropup'}} {{if nativeMobile 'hidden-xs'}} {{if disabled 'disabled'}} {{if showDropdown 'open'}}"
      tabindex="0">
   <button type="button"
           {{action "showHide"}}

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ember-cli-select-picker",
-  "version": "2.3.0",
+  "version": "2.3.1",
   "description": "A bootstrap 3 compatible select component",
   "author": "Devin Weaver (@sukima) <suki@tritarget.org>",
   "homepage": "https://sukima.github.io/ember-cli-select-picker/",


### PR DESCRIPTION
One problem with the menu is that if it is near the bottom of the page the CSS has it larger then the bottom of the page cutting of a portion of the menu. It is difficult to select something when it is clipped off and you can not scroll to it.

We calculate the relative sizing every time the page resizes or scrolls so that we can attach the `dropup` class. This class tells bootstrap to make the menu pop up instead of down allowing selects that are near the bottom to be visible.
