### PR TITLE
Add option to override the summaryMessage

### DIFF
--- a/addon/mixins/select-picker.js
+++ b/addon/mixins/select-picker.js
@@ -208,11 +208,13 @@ export default Ember.Mixin.create({
   selectionLabels: Ember.computed.mapBy('selectedContentList', 'label'),
 
   selectionSummary: Ember.computed(
-    'selectionLabels.[]', 'nothingSelectedMessage', 'summaryMessage', 'summaryMessageKey',
+    'selectionLabels.[]', 'nothingSelectedMessage', 'multipleSelectedMessage',
+    'summaryMessage', 'summaryMessageKey',
     function() {
-      var selection = this.get('selectionLabels');
-      var count = selection.get('length');
+      var selection  = this.get('selectionLabels');
+      var count      = selection.get('length');
       var messageKey = this.get('summaryMessageKey');
+      var message    = this.get('summaryMessage');
       if (Ember.I18n && Ember.isPresent(messageKey)) {
         // TODO: Allow an enablePrompt="false" feature
         if (count === 0) {
@@ -227,19 +229,22 @@ export default Ember.Mixin.create({
         // I18n is returning a string that's been escaped, we don't want the
         // string to get escaped again.
         return Ember.String.htmlSafe(translation);
-      }
-      switch (count) {
-        case 0:
-          return this.get('nothingSelectedMessage');
-        case 1:
-          return selection.get('firstObject');
-        default:
-          return Ember.String.fmt(
-            this.get('summaryMessage'),
-            count,
-            selection.get('firstObject'),
-            selection.join(', ')
-          );
+      } else if (Ember.isPresent(message)) {
+        return message;
+      } else {
+        switch (count) {
+          case 0:
+            return this.get('nothingSelectedMessage');
+          case 1:
+            return selection.get('firstObject');
+          default:
+            return Ember.String.fmt(
+              this.get('multipleSelectedMessage'),
+              count,
+              selection.get('firstObject'),
+              selection.join(', ')
+            );
+        }
       }
     }
   ),

--- a/app/components/select-picker.js
+++ b/app/components/select-picker.js
@@ -6,10 +6,10 @@ var I18nProps = (Ember.I18n && Ember.I18n.TranslateableProperties) || {};
 export default Ember.Component.extend(
   SelectPickerMixin, I18nProps, {
 
-  nothingSelectedMessage: 'Nothing Selected',
-  summaryMessage:         '%@ items selected',
-  selectAllLabel:         'All',
-  selectNoneLabel:        'None',
+  nothingSelectedMessage:  'Nothing Selected',
+  multipleSelectedMessage: '%@ items selected',
+  selectAllLabel:          'All',
+  selectNoneLabel:         'None',
 
   nativeMobile: true,
 


### PR DESCRIPTION
This was sort of working. It would allow you to customize the summary message only when there were multiple values selected.

Now if you add the summaryMessage property it will just use that regardless. It is up to the user to make it a computed property if you want it dynamic.
