### PR TITLE
Defer updateDropUp till after render

### DIFF
--- a/app/components/select-picker.js
+++ b/app/components/select-picker.js
@@ -29,7 +29,7 @@ export default Ember.Component.extend(
 
   setupDom: Ember.on('didInsertElement', function() {
     const id = this.get('elementId');
-    this.updateDropUp();
+    Ember.run.scheduleOnce('afterRender', this, this.updateDropUp);
     $(document)
       .on(`click.${id}`,      Ember.run.bind(this, this.hideDropdownMenu))
       .on(`touchstart.${id}`, Ember.run.bind(this, this.hideDropdownMenu))


### PR DESCRIPTION
Ember complains about a deprecation if you attempt to set a property in a didInsertElement call stack. Deferring this to afterRender removes the deprecation.
