### PR TITLE
Fix deprecation warning

### DIFF
--- a/addon/mixins/select-picker.js
+++ b/addon/mixins/select-picker.js
@@ -18,7 +18,7 @@ const emberArrayFunc = function(method) {
     }
   };
 };
-const _contains = emberArrayFunc('contains');
+const _includes = emberArrayFunc('includes');
 const _mapBy    = emberArrayFunc('mapBy');
 const _filterBy = emberArrayFunc('filterBy');
 const _findBy   = emberArrayFunc('findBy');
@@ -123,7 +123,7 @@ export default Ember.Mixin.create({
               group:    group,
               label:    label,
               value:    value,
-              selected: _contains(selection, value)
+              selected: _includes(selection, value)
             });
           } else {
             return null;


### PR DESCRIPTION
This PR fixes the deprecation warning in http://emberjs.com/deprecations/v2.x/#toc_enumerable-contains

The deprecation applies for Ember 2.8+, so anything less than that should break.
I suggest merging this after Ember hits 3.0
